### PR TITLE
Custom style in git-clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ The sequel assumes that you followed the installation steps bellow
   ```shell
   git clang-format --commit `git hash-object -t tree /dev/null`
   ```
-- Commit files
-  Nothing special to do! Unless you make modifications that do not match the formatting convention and don't use either the above or an extension in your editor. Then, you could not anymore make commit until you call `git clang-format`.
 
 ## Installing
-The pre-requisite is to have clang-format installed. On ubuntu, you can install the package `clang-format-x.y` where `x.y` is the version of clang-format. At the time of writing (March 2016), the latest version is 3.7.
+The pre-requisite is to have clang-format installed. On ubuntu 16.04, you can install the package `clang-format`. At the time of writing (June 2016) the latest version is 3.8, on Ubuntu 16.04.
 
-Check now that you can run `clang-format`. If it is not available with this name, try appending the verion number.
+Check now that you can run `clang-format`. If it is not available with this name, try appending the verion number, for instance `clang-format-3.7`.
 
 ### Integrate clang-format in git
 In your shell's configuration file, add the current repository to the path.
@@ -44,15 +42,16 @@ If you cannot run clang-fromat without specifying the version number, you'll als
 git config --global clangFormat.binary clang-format-3.7
 ```
 
-### Add the formatting convetion file (in EACH respository)
-In our team we use the `.clang-format` convention in this repository. To use it, create a symbolic link:
+### Add the formatting convetion file
+In our team we use the `.clang-format` convention in this repository. To have git-clang-format use it, we need to setup git config parameters:
 
 ```shell
-ln -s /PATH/TO/format_code/.clang-format /PATH/TO/YOUR/GIT/REPOSITORY/.clang-format
+git config --global clangFormat.style file
+git config --global --path clangFormat.stylePath /PATH/TO/format_code
 ```
 
 ### Pre-commit hook (in EACH respository)
-One might by mistake commit files that do not comply by the formatting convention. We can avoid this with a git hook, that is provided in this repository. To install, proceed as follow:
+One might, by mistake, commit files that do not comply with the formatting convention. We can avoid this with a git hook, provided in this repository. To install, proceed as follow:
 
 - give execution rights to the file  
   ```shell
@@ -64,7 +63,7 @@ One might by mistake commit files that do not comply by the formatting conventio
   ln -s /PATH/TO/format_code/pre-commit /PATH/TO/YOUR/GIT/REPOSITORY/.git/hooks/
   ```
 
-## Integrate clang-format with your favorite editor
+### Integrate with your favorite editor (optional)
 To spare you the need to manually run the formatter script, you can use a plugin for your favorite source code editor:
 
 - for Atom, install the plugin [clang-format](https://github.com/LiquidHelium/atom-clang-format)
@@ -75,13 +74,12 @@ For more information on clang-format, please have a look at
 
 - [Introduction to the clang tools](http://clang.llvm.org/docs/ClangTools.html)
 - [Documentation on the program clang-format](http://clang.llvm.org/docs/ClangFormat.html)
-
-You could also appreciate [clang format configurator](http://zed0.co.uk/clang-format-configurator/), that lets you see the effet of many clang-format's options.
+- [clang format configurator](http://zed0.co.uk/clang-format-configurator/), that lets you see the effet of many clang-format's options.
 
 ## Contributing
 Contributions for improvement or bug resolution are welcome, in the form of github issues or pull requests.
 
-If you want, you can write a script to setup a git repository for clang-format, based on the above installation procedure.
+If you want, you can write a script to install the git hook on several git repositories, based on the above installation procedure.
 
 ## License
 The software contained in the present repository is licensed under the (GNU GPL-compatible) CeCILL license. A copy can be found in `LICENSE`. `git-clang-format` is an exception, it is licensed under the the University of Illinois Open Source License, available in `LICENSE-clang-format`.

--- a/git-clang-format
+++ b/git-clang-format
@@ -154,7 +154,7 @@ def main():
   if opts.style_path:
     to_delete = copy_format_file(opts.style_path)
     if opts.verbose >= 1:
-      if already_exists:
+      if not to_delete:
         print ('There is already a clang-format style file:\n    ignoring the'
                'style path %s' % opts.style_path)
 

--- a/git-clang-format
+++ b/git-clang-format
@@ -44,6 +44,7 @@ The following git-config settings set the default of the corresponding option:
   clangFormat.commit
   clangFormat.extension
   clangFormat.style
+  clangFormat.stylePath
 '''
 
 # Name of the temporary index file in which save the output of clang-format.
@@ -109,6 +110,9 @@ def main():
   p.add_argument('--style',
                  default=config.get('clangformat.style', None),
                  help='passed to clang-format'),
+  p.add_argument('--style_path',
+                 default=config.get('clangformat.stylepath', None),
+                 help='path to the folder containing the .clang_format to use')
   p.add_argument('-v', '--verbose', action='count', default=0,
                  help='print extra information')
   # We gather all the remaining positional arguments into 'args' since we need
@@ -144,10 +148,22 @@ def main():
   # The computed diff outputs absolute paths, so we must cd before accessing
   # those files.
   cd_to_toplevel()
+
+  # If told to, temporarily retrieve a .clang-format style file
+  to_delete = False
+  if opts.style_path:
+    to_delete = copy_format_file(opts.style_path)
+    if opts.verbose >= 1:
+      if already_exists:
+        print ('There is already a clang-format style file:\n    ignoring the'
+               'style path %s' % opts.style_path)
+
   old_tree = create_tree_from_workdir(changed_lines)
   new_tree = run_clang_format_and_save_to_tree(changed_lines,
                                                binary=opts.binary,
                                                style=opts.style)
+  remove_format_file(to_delete)
+
   if opts.verbose >= 1:
     print 'old tree:', old_tree
     print 'new tree:', new_tree
@@ -315,6 +331,23 @@ def cd_to_toplevel():
   toplevel = run('git', 'rev-parse', '--show-toplevel')
   os.chdir(toplevel)
 
+def copy_format_file(format_folder):
+  """Copy the the custom format file to the current working directory.
+
+  The copy is only made if there is not already a .clang-format file in the
+  current directory.
+
+  Returns False when .clang-format already existed in the current directory"""
+
+  if not os.path.isfile(".clang-format"):
+    source_path = os.path.join(format_folder, ".clang-format")
+    if os.path.isfile(source_path):
+      subprocess.call(["cp", "-n", source_path, "."])
+      return True
+    else:
+      die('%s does not exist' % source_path)
+  else:
+    return False
 
 def create_tree_from_workdir(filenames):
   """Create a new git tree with the given files from the working directory.
@@ -418,6 +451,10 @@ def create_temporary_index(tree=None):
   run('git', 'read-tree', '--index-output='+path, tree)
   return path
 
+def remove_format_file(to_delete):
+  """Remove the clang format file, if it was first copied"""
+  if to_delete:
+    subprocess.call(["rm", ".clang-format"])
 
 def print_diff(old_tree, new_tree):
   """Print the diff between the two trees to stdout."""


### PR DESCRIPTION
With these modifications, we can use the same clang-format style everywhere, automatically.

@costashatz @jbmouret @vassilisvas  please test on your computer, so that we can start using this tool.
